### PR TITLE
fix incomplete listing when object list has more than 1000 items

### DIFF
--- a/systran_storages/storages/s3.py
+++ b/systran_storages/storages/s3.py
@@ -135,10 +135,9 @@ class S3Storage(Storage):
                                            'etag': key['ETag']}
                     if key['Key'].endswith('/'):
                         listdir[key['Key']]['is_dir'] = True
-            try:
-                list_objects_args['ContinuationToken'] = list_objects['NextContinuationToken']
-            except KeyError:
+            if 'NextContinuationToken' not in list_objects:
                 break
+            list_objects_args['ContinuationToken'] = list_objects['NextContinuationToken']
 
         return listdir
 

--- a/systran_storages/storages/s3.py
+++ b/systran_storages/storages/s3.py
@@ -116,18 +116,30 @@ class S3Storage(Storage):
         delimiter = '/'
         if recursive:
             delimiter = ''
-        list_objects = self._s3.meta.client.list_objects_v2(Bucket=self._bucket_name,
-                                                            Delimiter=delimiter,
-                                                            Prefix=remote_path)
-        if 'CommonPrefixes' in list_objects:
-            for key in list_objects['CommonPrefixes']:
-                listdir[key['Prefix']] = {'is_dir': True}
-        if 'Contents' in list_objects:
-            for key in list_objects['Contents']:
-                listdir[key['Key']] = {'size': key['Size'],
-                                       'last_modified': datetime_to_timestamp(key['LastModified'])}
-                if key['Key'].endswith('/'):
-                    listdir[key['Key']]['is_dir'] = True
+
+        list_objects_args={
+            'Bucket': self._bucket_name,
+            'Delimiter': delimiter,
+            'Prefix': remote_path
+        }
+
+        while True:
+            list_objects = self._s3.meta.client.list_objects_v2(**list_objects_args)
+            if 'CommonPrefixes' in list_objects:
+                for key in list_objects['CommonPrefixes']:
+                    listdir[key['Prefix']] = {'is_dir': True}
+            if 'Contents' in list_objects:
+                for key in list_objects['Contents']:
+                    listdir[key['Key']] = {'size': key['Size'],
+                                           'last_modified': datetime_to_timestamp(key['LastModified']),
+                                           'etag': key['ETag']}
+                    if key['Key'].endswith('/'):
+                        listdir[key['Key']]['is_dir'] = True
+            try:
+                list_objects_args['ContinuationToken'] = list_objects['NextContinuationToken']
+            except KeyError:
+                break
+
         return listdir
 
     def mkdir(self, remote_path):


### PR DESCRIPTION
the following script shows that the current implementation did not take into account paging in `list_objects_v2` API

```python
from systran_storages import StorageClient

services = {
            "s3":{"type":"s3", 
                  "bucket":"my-bucket"}
           }

client = StorageClient(services)

listing = client.listdir("s3:/", recursive=True)

print(len(listing))
```

I also expose the `Etag` header in the returned dictionary object.