### PR TITLE
Fix split/join methods to not return internal paths

### DIFF
--- a/systran_storages/storage.py
+++ b/systran_storages/storage.py
@@ -98,18 +98,19 @@ class StorageClient(object):
 
     def join(self, path, *paths):
         """Joins the paths according to the storage implementation."""
-        client, rel_path = self._get_storage(path)
-
-        if rel_path == path:
-            return client.join(path, *paths)
-
-        prefix, _ = path.split(':')
+        if not self.is_managed_path(path):
+            return os.path.join(path, *paths)
+        client, _ = self._get_storage(path)
+        prefix, rel_path = self.parse_managed_path(path)
         return '%s:%s' % (prefix, client.join(rel_path, *paths))  # Only join the actual path.
 
     def split(self, path):
         """Splits the path according to the storage implementation."""
-        client, path = self._get_storage(path)
-        return client.split(path)
+        if not self.is_managed_path(path):
+            return os.path.split(path)
+        client, _ = self._get_storage(path)
+        prefix, rel_path = self.parse_managed_path(path)
+        return ("%s:" % prefix,) + client.split(rel_path)
 
     # Simple wrappers around get().
     def get_file(self, remote_path, local_path, storage_id=None):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -290,6 +290,13 @@ def test_storages(request, tmpdir, storages, storage_id):
                                      storage_id=storage_id)
 
 
+def test_path_join():
+    config = {"local": {"type": "local", "basedir": "/tmp"}}
+    client = systran_storages.StorageClient(config)
+    assert client.join("local:dir/", "file.txt") == "local:dir/file.txt"
+    assert client.split("local:dir/file.txt") == ("local:", "dir", "file.txt")
+
+
 def test_is_managed_path():
     config = {"s3_models": {}, "s3_test": {}, "launcher": {}}
     client = systran_storages.StorageClient(config=config)


### PR DESCRIPTION
Before this change, the `split` and `join` methods returned invalid paths for storages with a base directory. Consider the following example:

```python
>>> config = {"local": {"type": "local", "basedir": "/tmp"}}
>>> client = systran_storages.StorageClient(config)
>>> client.join("local:", "file.txt")
'local:/tmp/file.txt'
```

However, `/tmp/file.txt` is not a valid path relative the base directory `/tmp` (i.e. `/tmp/tmp/file.txt` does not exist). The correct output is `local:file.txt`.

The methods have been updated to not return the internal path.