### PR TITLE
Remove non needed log message in Storage.get()

### DIFF
--- a/systran_storages/storages/generic.py
+++ b/systran_storages/storages/generic.py
@@ -110,7 +110,6 @@ class Storage(object):
             if check_integrity_fn is not None and check_integrity_fn(local_path, force=True):
                 LOGGER.info('Integrity check is successful for local directory: %s', local_path)
                 return
-            LOGGER.info('Continue to synchronize : %s', local_path)
             allfiles = {}
             for root, dirs, files in os.walk(local_path):
                 if os.path.basename(root) == _META_SUBDIR:


### PR DESCRIPTION
The method `StorageClient.get()` already logs "Synchronizing x to y", so this log message does not give additional useful information.