### PR TITLE
Disable boto3 logging

### DIFF
--- a/systran_storages/storages/s3.py
+++ b/systran_storages/storages/s3.py
@@ -11,6 +11,9 @@ import boto3
 from systran_storages.storages.utils import datetime_to_timestamp
 from systran_storages.storages import Storage
 
+for logger_name in ("boto3", "botocore", "s3transfer", "urllib3"):
+    logging.getLogger(logger_name).setLevel(logging.CRITICAL)
+
 LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
The DEBUG logs of `boto3` are *very* verbose.

I suggest disabling the logs entirely, as done in the Swift storage:

https://github.com/SYSTRAN/storages/blob/d51ca6d5eb9104f9fd2907ea25d351a17db3f836/systran_storages/storages/swift.py#L15-L16